### PR TITLE
Added basic support for FUSE mount options.

### DIFF
--- a/src/main/java/co/paralleluniverse/javafs/JavaFS.java
+++ b/src/main/java/co/paralleluniverse/javafs/JavaFS.java
@@ -3,6 +3,8 @@ package co.paralleluniverse.javafs;
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Path;
+import java.util.Map;
+
 import co.paralleluniverse.fuse.Fuse;
 
 /**
@@ -11,6 +13,22 @@ import co.paralleluniverse.fuse.Fuse;
  * @author pron
  */
 public final class JavaFS {
+	
+    /**
+     * Mounts a filesystem.
+     *
+     * @param fs           the filesystem
+     * @param mountPoint   the path of the mount point
+     * @param readonly     if {@code true}, mounts the filesystem as read-only
+     * @param log          if {@code true}, all filesystem calls will be logged with juc logging.
+     * @param mountOptions the platform specific mount options (e.g. {@code ro}, {@code rw}, etc.). {@code null} for value-less options.
+     */
+    public static void mount(FileSystem fs, Path mountPoint, boolean readonly, boolean log, Map<String, String> mountOptions) throws IOException {
+        if (readonly)
+            fs = new ReadOnlyFileSystem(fs);
+        Fuse.mount(new FuseFileSystemProvider(fs, log).log(log), mountPoint, false, log, mountOptions);
+    }
+    
     /**
      * Mounts a filesystem.
      *
@@ -20,11 +38,20 @@ public final class JavaFS {
      * @param log        if {@code true}, all filesystem calls will be logged with juc logging.
      */
     public static void mount(FileSystem fs, Path mountPoint, boolean readonly, boolean log) throws IOException {
-        if (readonly)
-            fs = new ReadOnlyFileSystem(fs);
-        Fuse.mount(new FuseFileSystemProvider(fs, log).log(log), mountPoint, false, log);
+        mount(fs,mountPoint, readonly, log, null);
     }
 
+    /**
+     * Mounts a filesystem.
+     *
+     * @param fs           the filesystem
+     * @param mountPoint   the path of the mount point
+     * @param mountOptions the platform specific mount options (e.g. {@code ro}, {@code rw}, etc.).  {@code null} for value-less options.
+     */
+    public static void mount(FileSystem fs, Path mountPoint, Map<String, String> mountOptions) throws IOException {
+        mount(fs, mountPoint, false, false, mountOptions);
+    }
+    
     /**
      * Mounts a filesystem.
      *
@@ -32,7 +59,7 @@ public final class JavaFS {
      * @param mountPoint the path of the mount point
      */
     public static void mount(FileSystem fs, Path mountPoint) throws IOException {
-        mount(fs, mountPoint, false, false);
+        mount(fs, mountPoint, false, false, null);
     }
 
     /**

--- a/src/test/java/co/paralleluniverse/javafs/Main.java
+++ b/src/test/java/co/paralleluniverse/javafs/Main.java
@@ -1,8 +1,11 @@
 package co.paralleluniverse.javafs;
 
 import com.google.common.jimfs.Jimfs;
+
 import java.nio.file.FileSystem;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 
 public class Main {
     public static void main(final String... args) throws Exception {
@@ -23,7 +26,10 @@ public class Main {
             System.out.println("Mounting filesystem " + fs + " at " + mountPoint + (readonly ? " READONLY" : ""));
             System.out.println("========================");
             
-            JavaFS.mount(fs, Paths.get(mountPoint), readonly, true);
+            Map<String, String> options = new HashMap<>();
+            options.put("fsname", fs.getClass().getSimpleName() + "@" + System.currentTimeMillis());
+            
+            JavaFS.mount(fs, Paths.get(mountPoint), readonly, true, options);
             Thread.sleep(Long.MAX_VALUE);
         } catch (IllegalArgumentException e) {
             System.err.println("Usage: JavaFS [-r] <mountpoint> [<zipfile>]");


### PR DESCRIPTION
I think in the future adding a builder construct might be nice, but for now this at least allows the user to pass options to the underlying implementation. See `Main` for an example of changing the file system name. Use `mount` to see it reflected.
