### PR TITLE
Make ErrorCodes publicly accessable

### DIFF
--- a/src/main/java/co/paralleluniverse/fuse/ErrorCodes.java
+++ b/src/main/java/co/paralleluniverse/fuse/ErrorCodes.java
@@ -1,6 +1,6 @@
 package co.paralleluniverse.fuse;
 
-final class ErrorCodes {
+public final class ErrorCodes {
     private static final class ErrorCodesBSD implements IErrorCodes {
         @Override public int E2BIG()         { return 7; }
         @Override public int EACCES()        { return 13; }


### PR DESCRIPTION
I am trying to implement a subclass of `AbstractFuseFilesystem` and need to be able to return error codes. For example:

```
protected synchronized int readdir(String path, StructFuseFileInfo info, DirectoryFiller filler) {
        if(!mVirtualFS.pathExists(path)) {
            return -ErrorCodes.ENOENT();
        }
```
