### PR TITLE
Update FuseFileSystemProvider.java - return the correct value from read method

### DIFF
--- a/src/main/java/co/paralleluniverse/javafs/FuseFileSystemProvider.java
+++ b/src/main/java/co/paralleluniverse/javafs/FuseFileSystemProvider.java
@@ -305,8 +305,11 @@ class FuseFileSystemProvider extends FuseFilesystem {
                             n += c;
                         }
                     }
+                     return n;
+                }else{
+                    return 0; // we did not read any bytes
                 }
-                return n;
+               
             } else if (channel instanceof AsynchronousFileChannel) {
                 final AsynchronousFileChannel ch = ((AsynchronousFileChannel) channel);
                 int n = ch.read(buffer, offset).get();


### PR DESCRIPTION
when reading from the buffer in line 296, if we got -1 it means 0 bytes were read, so we need to return 0, because this is the right value for n