### PR TITLE
Fixed platform support for Mac M1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,12 +28,12 @@ repositories {
 }
 
 dependencies {
-    compile 'com.github.jnr:jnr-ffi:2.0.3'    
-    compile 'com.github.jnr:jnr-posix:3.0.17'
+    compile 'com.github.jnr:jnr-ffi:2.2.12'
+    compile 'com.github.jnr:jnr-posix:3.1.15'
     
     testCompile 'junit:junit:4.12'
     testCompile 'org.truth0:truth:0.23'
-    testCompile 'com.google.jimfs:jimfs:1.0'
+    testCompile 'com.google.jimfs:jimfs:1.2'
 }
 
 tasks.withType(JavaExec) {
@@ -119,11 +119,6 @@ uploadArchives {
         }
     }
 }
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '2.4'
-}
-
 
 task('run', type: JavaExec, dependsOn:[testClasses]) {
     classpath = sourceSets.main.runtimeClasspath + sourceSets.test.runtimeClasspath

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Sep 04 17:18:36 IDT 2015
+#Sat Oct 22 00:20:50 CST 2022
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.3-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-bin.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/co/paralleluniverse/filesystem/FileSystemAdapter.java
+++ b/src/main/java/co/paralleluniverse/filesystem/FileSystemAdapter.java
@@ -19,13 +19,6 @@ public abstract class FileSystemAdapter extends FileSystem {
         this.fsp = fsp;
     }
 
-//    protected FileSystemAdapter(FileSystem fs) {
-//        this.fs = fs;
-//        this.fsp = wrapFileSystemProvider(fs.provider());
-//    }
-//    protected FileSystemProvider wrapFileSystemProvider(FileSystemProvider fsp) {
-//        return fsp;
-//    }
     @Override
     public String toString() {
         return fs.toString();

--- a/src/main/java/co/paralleluniverse/javafs/FuseFileSystemProvider.java
+++ b/src/main/java/co/paralleluniverse/javafs/FuseFileSystemProvider.java
@@ -538,21 +538,6 @@ class FuseFileSystemProvider extends FuseFilesystem {
     protected int lock(String path, StructFuseFileInfo info, int command, StructFlock flock) {
         try {
             throw new UnsupportedOperationException();
-//            if (command == StructFlock.CMD_GETLK)
-//                throw new UnsupportedOperationException();
-//
-//            final Channel channel = toChannel(info);
-//            if (channel instanceof FileChannel) {
-//                FileChannel ch = (FileChannel) channel;
-//                switch (command) {
-//                    case StructFlock.CMD_SETLK:
-//                        FileLock lock = ch.lock(flock.start(), flock.len(), false);
-//                        lock.
-//                }
-//            } else if (channel instanceof AsynchronousFileChannel) {
-//                AsynchronousFileChannel ch = (AsynchronousFileChannel) channel;
-//            }
-//            return 0;
         } catch (Exception e) {
             return -errno(e);
         }

--- a/src/test/java/co/paralleluniverse/javafs/JFSTest.java
+++ b/src/test/java/co/paralleluniverse/javafs/JFSTest.java
@@ -5,7 +5,6 @@
  */
 package co.paralleluniverse.javafs;
 
-import co.paralleluniverse.javafs.JavaFS;
 import com.google.common.jimfs.Jimfs;
 import static com.google.common.truth.Truth.assert_;
 import java.io.DataInputStream;


### PR DESCRIPTION
1. upgrade gradle version to fix sync failure
2. upgrade jnr versions to support macFUSE in Mac M1 laptop
3. fix compatible issues caused by upgraded jnr versions